### PR TITLE
Pull Workadventure (and Jitsi) from ffdorf/workadventure-k8s

### DIFF
--- a/environments/dev/app-workadventure/git-repository.yaml
+++ b/environments/dev/app-workadventure/git-repository.yaml
@@ -1,0 +1,10 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta1
+kind: GitRepository
+metadata:
+  name: app-workadventure
+  namespace: app-workadventure
+spec:
+  interval: 1m0s
+  ref:
+    branch: main
+  url: https://github.com/ffddorf/workadventure-k8s


### PR DESCRIPTION
I'm not sure what will Flux do with the mismatching namespace in GitRepository vs the namespaces in the manifests of Workadventure and Jitsi.

I'll split Jitsi off into its own repo soon (tm).